### PR TITLE
サマリー分割モードで連携登録したときにも相手側記入のサマリーが入るようにした

### DIFF
--- a/app/models/entry/base.rb
+++ b/app/models/entry/base.rb
@@ -7,6 +7,7 @@ class Entry::Base < ApplicationRecord
   include Booking
 
   MAX_LINE_NUMBER = 999 # 処理の都合上、上限があったほうが安心なため片側最大行数を決める
+  SUMMARY_MAX_SIZE = 64
   
   belongs_to :account,
              :class_name => 'Account::Base',

--- a/lib/user/account_linking.rb
+++ b/lib/user/account_linking.rb
@@ -91,9 +91,8 @@ module User::AccountLinking
               linked_entries_side ||= e.creditor ? :creditor : :debtor
             end
             # 未確認なら相手entryは1つである想定だけど全部としておく
-            partner_entry_ids = (linked_entries_side == :creditor? ? linked_deal.debtor_entries : linked_deal.creditor_entries).map(&:id)
-            # ここでsaveしたくないみたいだけどないときはsaveしちゃってるし、いったん相手のほうはサマリー変更を終わらせる
-            Entry::Base.where(id: partner_entry_ids).update_all(summary: partner_entry_summary)
+            # ここでsaveしたくないみたいだけどはじめての連携時はsaveしちゃってるし、いったん相手のほうはサマリー変更を終わらせる
+            (linked_entries_side == :creditor? ? linked_deal.debtor_entries : linked_deal.creditor_entries).each{|e| e.update_columns(summary: partner_entry_summary)}
           end
         end
 

--- a/spec/models/deal/linking_spec.rb
+++ b/spec/models/deal/linking_spec.rb
@@ -136,6 +136,8 @@ describe "Deal Linking" do
           expect(linked_deal).not_to be_nil
           # 花子側の借方に連携が入る
           expect(linked_deal.debtor_entries.map(&:summary)).to eq ['[太郎]ラーメン']
+          # 花子側の貸し方にも同じものがはいる
+          expect(linked_deal.creditor_entries.map(&:summary)).to eq ['[太郎]ラーメン']
         end
       end
 
@@ -157,6 +159,8 @@ describe "Deal Linking" do
             expect(linked_deal).not_to be_nil
             # 花子側の借方に連携が入る
             expect(linked_deal.debtor_entries.map(&:summary)).to eq ['[太郎]味噌ラーメン']
+            # 花子側の貸し方にも同じサマリーがはいる
+            expect(linked_deal.creditor_entries.map(&:summary)).to eq ['[太郎]味噌ラーメン']
           end
         end
 
@@ -176,6 +180,8 @@ describe "Deal Linking" do
             # 花子側の借方に連携が入る
             expect(linked_deal.debtor_entries.map(&:summary)).to eq ['ラーメンと菓子']
             expect(linked_deal.summary_unified?).to be_truthy
+            # 花子側の貸し方にも同じサマリーが入る
+            expect(linked_deal.creditor_entries.map(&:summary)).to eq ['ラーメンと菓子']
           end
         end
       end
@@ -197,6 +203,8 @@ describe "Deal Linking" do
           expect(linked_deal).not_to be_nil
           # 花子側の借方に連携が入る
           expect(linked_deal.debtor_entries.map(&:summary)).to eq ['[太郎]ラーメン', '[太郎]菓子']
+          # 花子側の貸し方には最初の１つに「、他」をつけたサマリーがはいる
+          expect(linked_deal.creditor_entries.map(&:summary)).to eq ['[太郎]ラーメン、他']
         end
       end
 
@@ -209,15 +217,32 @@ describe "Deal Linking" do
           before do
             deal.attributes = {
               :debtor_entries_attributes => deal.debtor_entries.map{|e| {:account_id => e.account_id, :amount => e.amount, :id => e.id, :line_number => e.line_number, :summary => e.summary}},
-              :creditor_entries_attributes => deal.creditor_entries.map{|e| {:account_id => e.account_id, :amount => e.amount, :id => e.id, :line_number => e.line_number, :summary => e.summary == '[太郎]ラーメン' ? '[太郎]味噌ラーメン' : e.summary}}
+              :creditor_entries_attributes => deal.creditor_entries.map{|e| {:account_id => e.account_id, :amount => e.amount, :id => e.id, :line_number => e.line_number, :summary => e.summary == '[太郎]ラーメン' ? new_summary : e.summary}}
             }
           end
-          it "更新が成功し、変更後のサマリーが連携記入に含まれる" do
-            expect(deal.save).to be_truthy
-            linked_deal = hanako.linked_deal_for(taro.id, deal.id)
-            expect(linked_deal).not_to be_nil
-            # 花子側の借方に連携が入る
-            expect(linked_deal.debtor_entries.map(&:summary)).to eq ['[太郎]味噌ラーメン', '[太郎]菓子']
+          context "変更後のサマリーが10文字のとき" do
+            let(:new_summary) { '[太郎]味噌ラーメン' }
+            it "更新が成功し、変更後のサマリーが連携記入に含まれる" do
+              expect(deal.save).to be_truthy
+              linked_deal = hanako.linked_deal_for(taro.id, deal.id)
+              expect(linked_deal).not_to be_nil
+              # 花子側の借方に連携が入る
+              expect(linked_deal.debtor_entries.map(&:summary)).to eq ['[太郎]味噌ラーメン', '[太郎]菓子']
+              # 花子側の貸し方には最初の１つに「、他」をつけたサマリーがはいる
+              expect(linked_deal.creditor_entries.map(&:summary)).to eq ['[太郎]味噌ラーメン、他']
+            end
+          end
+          context "変更後のサマリーが64文字のとき" do
+            let(:new_summary) { '＊' * 64 }
+            it "更新が成功し、変更後のサマリーが連携記入に含まれる" do
+              expect(deal.save).to be_truthy
+              linked_deal = hanako.linked_deal_for(taro.id, deal.id)
+              expect(linked_deal).not_to be_nil
+              # 花子側の借方に連携が入る
+              expect(linked_deal.debtor_entries.map(&:summary)).to eq [new_summary, '[太郎]菓子']
+              # 花子側の貸し方には最初の１つをtruncateして「、他」をつけたサマリーがはいる
+              expect(linked_deal.creditor_entries.map(&:summary)).to eq ["#{'＊' * 59}...、他"]
+            end
           end
         end
 
@@ -237,6 +262,8 @@ describe "Deal Linking" do
             # 花子側の借方に連携が入る
             expect(linked_deal.debtor_entries.map(&:summary)).to eq ['ラーメンと菓子', 'ラーメンと菓子']
             expect(linked_deal.summary_unified?).to be_truthy
+            # 花子側の貸し方にも同じサマリーが入る
+            expect(linked_deal.creditor_entries.map(&:summary)).to eq ['ラーメンと菓子']
           end
         end
       end


### PR DESCRIPTION
# Overview
サマリー分割モードで連携登録したときにも相手側記入のサマリーが入るようにした

# Related Issues
https://github.com/nay/kozuchi/issues/209

# Details
