### PR TITLE
口座別の記入画面に出る精算へのリンクを今・翌・翌々月に変更

### DIFF
--- a/app/controllers/deals_controller.rb
+++ b/app/controllers/deals_controller.rb
@@ -225,7 +225,7 @@ class DealsController < ApplicationController
 
     # 上部精算概況
     if @account && @account.any_credit?
-      @settlement_summaries = SettlementSummaries.new(current_user, past: 1, future: 1, target_account: @account, target_date: start_date)
+      @settlement_summaries = SettlementSummaries.new(current_user, past: 0, future: 2, target_account: @account, target_date: start_date)
     end
 
     # 上部折れ線グラフ


### PR DESCRIPTION
# Overview
口座別の記入画面に出る精算へのリンクを前・今・翌月から今・翌・翌々月に変更しました。

# Related Issues
#147

# Details
