### PR TITLE
サジェッションで口座が違うものを別項目に分離

### DIFF
--- a/app/models/entry/general.rb
+++ b/app/models/entry/general.rb
@@ -14,10 +14,10 @@ class Entry::General < Entry::Base
 
   scope :recent_summaries, ->(keyword) {
     select("summary, max(deal_id) as deal_id"
-    ).group("summary"
+    ).group("summary, account_id"
     ).where("summary like ?", "#{keyword}%"
     ).order("deal_id desc"
-    ).limit(5)
+    ).limit(10)
   }
 
   def partner_account_name

--- a/spec/factories/deals.rb
+++ b/spec/factories/deals.rb
@@ -5,21 +5,39 @@ FactoryBot.define do
   # 単純な記入
   # デフォルトでは太郎の現金→食費
   factory :general_deal, :class => Deal::General do
+    transient do
+      creditor_account_id { Fixtures.identify(:taro_cache) }
+    end
+    trait :cache do
+      creditor_account_id { Fixtures.identify(:taro_cache) }
+    end
+    trait :card do
+      creditor_account_id { Fixtures.identify(:taro_card) }
+    end
     user_id                     { Fixtures.identify(:taro) }
     summary                     { "ランチ" }
     summary_mode                { 'unify' }
     debtor_entries_attributes   { [:account_id => Fixtures.identify(:taro_food), :amount => 800] }
-    creditor_entries_attributes { [:account_id => Fixtures.identify(:taro_cache), :amount => -800] }
+    creditor_entries_attributes { [:account_id => creditor_account_id, :amount => -800] }
     date                        { Time.zone.today }
   end
 
   # 複数記入
   factory :complex_deal, :class => Deal::General do
+    transient do
+      creditor_account_id { Fixtures.identify(:taro_cache) }
+    end
+    trait :cache do
+      creditor_account_id { Fixtures.identify(:taro_cache) }
+    end
+    trait :card do
+      creditor_account_id { Fixtures.identify(:taro_card) }
+    end
     user_id                     { Fixtures.identify(:taro) }
     summary                     { '買い物' }
     summary_mode                { 'unify' }
     debtor_entries_attributes   { [{:account_id => Fixtures.identify(:taro_food), :amount => 800, :line_number => 0}, {:account_id => Fixtures.identify(:taro_other), :amount => 200, :line_number => 1}] }
-    creditor_entries_attributes { [:account_id => Fixtures.identify(:taro_cache), :amount => -1000, :line_number => 0] }
+    creditor_entries_attributes { [:account_id => creditor_account_id, :amount => -1000, :line_number => 0] }
     date                        { Time.zone.today }
   end
 

--- a/spec/features/deals_js_spec.rb
+++ b/spec/features/deals_js_spec.rb
@@ -188,7 +188,9 @@ describe DealsController, js: true, type: :feature do
         let(:summary) { "朝食のサンドイッチ" }
         let(:suggestion_with_amount) { true }
         before do
-          create(deal_type, :date => Time.zone.today, :summary => summary)
+          create(deal_type, :card, :date => Time.zone.today, :summary => summary)
+          create(deal_type, :cache, :date => Time.zone.today, :summary => summary)
+
           fill_in 'deal_summary', :with => '朝食'
           expect(page).to have_css("#patterns div.clickable_text") # サジェッションが表示される
           clickable_text_index = suggestion_with_amount ? 0 : 1
@@ -257,6 +259,8 @@ describe DealsController, js: true, type: :feature do
 
         it "先に登録したデータがサジェッション表示される" do
           expect(page).to have_css("#patterns div.clickable_text")
+          expect(page.find('#patterns')).to have_content('現金')
+          expect(page.find('#patterns')).to have_content('クレジットカードＸ')
         end
 
       end


### PR DESCRIPTION
# Overview
サジェッションの候補で口座が違うものを別項目として分離しました。

# Related Issues
なし

# Details
現金とクレジットカードや電子マネー等複数口座で同じ摘要の明細を繰り返し入力する場合に、最後に入力した口座のみがサジェストされ、度々手動で修正する必要があるため、それぞれの口座のものを別項目としてサジェストしてくれると良いと思いました。

`recent_summaries` scopeにおいて、摘要に加えて口座IDでグループ化するようにしました。この際に、maxを取った後でも同じ`deal_id`が重複して出るため、重複が出る前提でlimitを多めに10としています。（もう少し良いクエリの書き方がありそうな気はします。）

別口座のものを別項目として分離すべきかどうかは好みの問題もあると思いますので、もし小槌の方針に合うようであれば取り込んでください。

テストも作りましたが、既存のサジェッションのテストに口座の異なるエントリを複数作成する処理をそのままではうまく追加できなかったので、テストデータの口座を変更できるようにfactoryの定義にtraitとtransientを追加しています。設計上合わないようであればご指摘ください。

PS: 口座だけでなく金額についても過去の履歴をいくつか出してくれると嬉しいのですが、UIが難しそうです。