### PR TITLE
摘要が長すぎるときの処理の改善

### DIFF
--- a/app/controllers/deals_controller.rb
+++ b/app/controllers/deals_controller.rb
@@ -70,7 +70,7 @@ class DealsController < ApplicationController
       @deal = current_user.send(deal_type.to_s =~ /general|complex/ ? 'general_deals' : 'balance_deals').new(deal_params)
       if @deal.save
         truncated_message = @deal.summary_truncated? ? "長すぎる摘要を64文字に短縮しました。" : ""
-        flash[:notice] = "#{@deal.human_name} を追加しました。#{truncated_message}" # TODO: 他コントーラとDRYに
+        flash[:notice] = "#{@deal.human_name} を追加しました。#{truncated_message}"
         flash[:"#{controller_name}_deal_type"] = deal_type
         write_target_date(@deal.date)
         account_has_been_selected(*@deal.accounts)

--- a/app/controllers/deals_controller.rb
+++ b/app/controllers/deals_controller.rb
@@ -69,8 +69,7 @@ class DealsController < ApplicationController
       size = deal_params[:creditor_entries_attributes].kind_of?(Array) ? deal_params[:creditor_entries_attributes].size : deal_params[:creditor_entries_attributes].try(:to_h).try(:size)
       @deal = current_user.send(deal_type.to_s =~ /general|complex/ ? 'general_deals' : 'balance_deals').new(deal_params)
       if @deal.save
-        truncated_message = @deal.summary_truncated? ? "長すぎる摘要を64文字に短縮しました。" : ""
-        flash[:notice] = "#{@deal.human_name} を追加しました。#{truncated_message}"
+        flash[:notice] = "#{@deal.human_name} を追加しました。#{truncation_message(@deal)}"
         flash[:"#{controller_name}_deal_type"] = deal_type
         write_target_date(@deal.date)
         account_has_been_selected(*@deal.accounts)
@@ -155,7 +154,7 @@ class DealsController < ApplicationController
     if @deal.save
       write_target_date(@deal.date)
       account_has_been_selected(*@deal.accounts)
-      flash[:notice] = "#{@deal.human_name} を更新しました。" # TODO: 他コントーラとDRYに
+      flash[:notice] = "#{@deal.human_name} を更新しました。#{truncation_message(@deal)}"
       flash[:"#{controller_name}_deal_type"] = deal_type
       flash[:day] = @deal.date.day
       render json: {
@@ -297,6 +296,10 @@ class DealsController < ApplicationController
   end
 
   private
+
+  def truncation_message(deal)
+    deal.summary_truncated? ? "長すぎる摘要を64文字に短縮しました。" : ""
+  end
 
   def data_for_day_navigator
     current_user.deals.in_month(@year, @month).order(:date, :daily_seq).select(:date).distinct

--- a/app/controllers/deals_controller.rb
+++ b/app/controllers/deals_controller.rb
@@ -69,7 +69,8 @@ class DealsController < ApplicationController
       size = deal_params[:creditor_entries_attributes].kind_of?(Array) ? deal_params[:creditor_entries_attributes].size : deal_params[:creditor_entries_attributes].try(:to_h).try(:size)
       @deal = current_user.send(deal_type.to_s =~ /general|complex/ ? 'general_deals' : 'balance_deals').new(deal_params)
       if @deal.save
-        flash[:notice] = "#{@deal.human_name} を追加しました。" # TODO: 他コントーラとDRYに
+        truncated_message = @deal.summary_truncated? ? "長すぎる摘要を64文字に短縮しました。" : ""
+        flash[:notice] = "#{@deal.human_name} を追加しました。#{truncated_message}" # TODO: 他コントーラとDRYに
         flash[:"#{controller_name}_deal_type"] = deal_type
         write_target_date(@deal.date)
         account_has_been_selected(*@deal.accounts)

--- a/app/models/concerns/entry/summary_truncation.rb
+++ b/app/models/concerns/entry/summary_truncation.rb
@@ -1,0 +1,23 @@
+module Entry::SummaryTruncation
+  extend ActiveSupport::Concern
+
+  SUMMARY_MAX_SIZE = 64
+
+  included do
+    before_validation :truncate_summary
+
+  end
+
+  def summary_truncated?
+    @summary_truncated
+  end
+
+  private
+
+  def truncate_summary
+    if summary && summary.length > SUMMARY_MAX_SIZE
+      self.summary = summary.truncate(SUMMARY_MAX_SIZE)
+      @summary_truncated = true # 登録・更新の開始時は新たにオブジェクトが作られてnilになっていることを想定している
+    end
+  end
+end

--- a/app/models/deal/balance.rb
+++ b/app/models/deal/balance.rb
@@ -18,7 +18,7 @@ class Deal::Balance < Deal::Base
   after_save :update_initial_balance
   after_destroy :update_initial_balance
 
-  delegate :account_id=, :account_id, :account, :balance=, :balance, :balance_before_type_cast, :amount, :summary, :initial_balance?, :balance_before, :to => :prepared_entry
+  delegate :account_id=, :account_id, :account, :balance=, :balance, :balance_before_type_cast, :amount, :summary, :initial_balance?, :balance_before, :summary_truncated?, to: :prepared_entry
 
   def balance?
     true

--- a/app/models/entry/base.rb
+++ b/app/models/entry/base.rb
@@ -7,8 +7,7 @@ class Entry::Base < ApplicationRecord
   include Booking
 
   MAX_LINE_NUMBER = 999 # 処理の都合上、上限があったほうが安心なため片側最大行数を決める
-  SUMMARY_MAX_SIZE = 64
-  
+
   belongs_to :account,
              :class_name => 'Account::Base',
              :foreign_key => 'account_id'
@@ -128,7 +127,7 @@ class Entry::Base < ApplicationRecord
   end
 
   private
-  
+
   def check_amount_exists
     # Entry::General では検証で防ぐ。Entry::Balanceの場合は検証を突破して自動で入れるため、ここでチェックする
     raise "no amount in #{inspect}" if amount.blank?

--- a/app/models/entry/base.rb
+++ b/app/models/entry/base.rb
@@ -5,6 +5,7 @@ class Entry::Base < ApplicationRecord
   unsavable
 
   include Booking
+  include Entry::SummaryTruncation
 
   MAX_LINE_NUMBER = 999 # 処理の都合上、上限があったほうが安心なため片側最大行数を決める
 

--- a/app/models/pattern/entry.rb
+++ b/app/models/pattern/entry.rb
@@ -7,6 +7,7 @@ class Pattern::Entry < ApplicationRecord
              :foreign_key => 'account_id'
 
   include ::Entry
+  include Entry::SummaryTruncation
 #  attr_accessible :account_id, :amount, :line_number, :summary, :reversed_amount
 
   def assignable_attributes

--- a/lib/deal.rb
+++ b/lib/deal.rb
@@ -1,4 +1,5 @@
 # -*- encoding : utf-8 -*-
+# NOTE: saveしたオブジェクトで再度更新を行う場合、entry内の@summary_truncated が最初の登録/更新でtrueになった場合はそれを引き継ぐ。必要ならリセットする。
 module Deal
 
   module AccountCareExtension
@@ -214,6 +215,10 @@ module Deal
         errors.delete(:"creditor_entries.#{attr}")
       end
     end
+  end
+
+  def summary_truncated?
+    active_entries.any?(&:summary_truncated?)
   end
 
   private

--- a/lib/deal.rb
+++ b/lib/deal.rb
@@ -1,5 +1,4 @@
 # -*- encoding : utf-8 -*-
-# NOTE: saveしたオブジェクトで再度更新を行う場合、entry内の@summary_truncated が最初の登録/更新でtrueになった場合はそれを引き継ぐ。必要ならリセットする。
 module Deal
 
   module AccountCareExtension
@@ -69,8 +68,10 @@ module Deal
   def self.included(base)
     base.accepts_nested_attributes_for :debtor_entries, :creditor_entries, :allow_destroy => true
     base.before_validation :copy_deal_info_to_entries, :set_creditor_to_entries, :set_unified_summary
+    base.after_validation :get_summary_truncated # 後の工程でentryオブジェクトが入れ替わってしまい状態が失われるので取得しておく
     base.before_save :adjust_entry_line_numbers
     base.before_update :destroy_marked_entries
+    base.after_save :clear_unified_summary # entry側でtruncateされて変化したときにそれをsummaryとして扱えるようにする
 
     base.class_eval do
       # 単一記入では creditor に金額が指定されないことへの調整。
@@ -167,7 +168,7 @@ module Deal
   end
 
   def reload
-    @unified_summary = nil
+    clear_unified_summary
     super
   end
 
@@ -218,10 +219,18 @@ module Deal
   end
 
   def summary_truncated?
-    active_entries.any?(&:summary_truncated?)
+    @summary_truncated
   end
 
   private
+
+  def get_summary_truncated
+    @summary_truncated = active_entries.any?(&:summary_truncated?)
+  end
+
+  def clear_unified_summary
+    @unified_summary = nil
+  end
 
   # Rails を 3.2.6 から 3.2.11 にあげたら、
   # nested attributes の autosave で削除よりさきにentry登録がはしって

--- a/lib/entry.rb
+++ b/lib/entry.rb
@@ -1,7 +1,10 @@
 # -*- encoding : utf-8 -*-
 module Entry
 
+  SUMMARY_MAX_SIZE = 64
+
   def self.included(base)
+    base.before_validation :truncate_summary
     base.validates :amount, :numericality => {:only_integer => true, :allow_blank => true}
     base.validate :validate_amount_is_not_zero
 
@@ -57,7 +60,18 @@ module Entry
     !id.to_s.blank? && attributes[:id].to_s == id.to_s
   end
 
+  def summary_truncated?
+    @summary_truncated
+  end
+
   private
+
+  def truncate_summary
+    if summary && summary.length > SUMMARY_MAX_SIZE
+      self.summary = summary.truncate(SUMMARY_MAX_SIZE)
+      @summary_truncated = true # 登録・更新の開始時は新たにオブジェクトが作られてnilになっていることを想定している
+    end
+  end
 
   def validate_amount_is_not_zero
     errors.add :amount, "に0を指定することはできません。" if amount && amount.to_i == 0 && errors[:amount].empty?

--- a/lib/entry.rb
+++ b/lib/entry.rb
@@ -1,10 +1,8 @@
 # -*- encoding : utf-8 -*-
+# TODO: balance を代表していないので、Entry::Amount 等に名前変更したい
 module Entry
 
-  SUMMARY_MAX_SIZE = 64
-
   def self.included(base)
-    base.before_validation :truncate_summary
     base.validates :amount, :numericality => {:only_integer => true, :allow_blank => true}
     base.validate :validate_amount_is_not_zero
 
@@ -60,18 +58,7 @@ module Entry
     !id.to_s.blank? && attributes[:id].to_s == id.to_s
   end
 
-  def summary_truncated?
-    @summary_truncated
-  end
-
   private
-
-  def truncate_summary
-    if summary && summary.length > SUMMARY_MAX_SIZE
-      self.summary = summary.truncate(SUMMARY_MAX_SIZE)
-      @summary_truncated = true # 登録・更新の開始時は新たにオブジェクトが作られてnilになっていることを想定している
-    end
-  end
 
   def validate_amount_is_not_zero
     errors.add :amount, "に0を指定することはできません。" if amount && amount.to_i == 0 && errors[:amount].empty?

--- a/spec/controllers/deals_controller_spec.rb
+++ b/spec/controllers/deals_controller_spec.rb
@@ -172,24 +172,36 @@ describe DealsController, type: :controller do
   end
 
   describe "update" do
+    let(:summary) { 'changed like test_complex' }
     before do
       @deal = create_deal(:confirmed => false)
-    end
-    it "成功する" do
       put :update, params: {
-            :id => @deal.id, :deal => {
-            :year => '2010', :month => '7', :day => '9',
-            :summary => 'changed like test_complex',
-            :summary_mode => 'unify',
-            :creditor_entries_attributes => {'0' => {:account_id => :taro_cache.to_id, :amount => -800, :line_number => 0}, '1' => {:account_id => :taro_hanako.to_id, :amount => -200, :line_number => 1}},
-            :debtor_entries_attributes => {'0' => {:account_id => :taro_bank.to_id, :amount => 1000, :line_number => 0}}
+          :id => @deal.id, :deal => {
+              :year => '2010', :month => '7', :day => '9',
+              :summary => summary,
+              :summary_mode => 'unify',
+              :creditor_entries_attributes => {'0' => {:account_id => :taro_cache.to_id, :amount => -800, :line_number => 0}, '1' => {:account_id => :taro_hanako.to_id, :amount => -200, :line_number => 1}},
+              :debtor_entries_attributes => {'0' => {:account_id => :taro_bank.to_id, :amount => 1000, :line_number => 0}}
           }
       }
+    end
+    it "成功する" do
       expect(response).to be_successful
       @deal.reload
       expect(@deal.creditor_entries.size).to eq 2
       expect(@deal.summary).to eq 'changed like test_complex'
       expect(@deal.date).to eq Date.new(2010, 7, 9)
+    end
+
+    context "摘要が100文字のとき" do
+      let(:summary) { "a" * 100 }
+      it "成功し、摘要が切り詰められ、Flashメッセージで切り詰めが報告される" do
+        expect(response).to be_successful
+        @deal.reload
+        expect(@deal.summary).to eq "a" * 61 + "..."
+        expect(controller.instance_variable_get("@deal").summary).to eq  "a" * 61 + "..."
+        expect(request.flash[:notice]).to eq "記入 2010/07/09-1 を更新しました。長すぎる摘要を64文字に短縮しました。"
+      end
     end
   end
 

--- a/spec/controllers/deals_controller_spec.rb
+++ b/spec/controllers/deals_controller_spec.rb
@@ -125,6 +125,7 @@ describe DealsController, type: :controller do
       expect(deal).not_to be_nil
       expect(deal.balance).to eq 3000
     end
+    # 残高には摘要を入れないので長すぎる状態は生じない
   end
 
   describe "search" do

--- a/spec/controllers/deals_controller_spec.rb
+++ b/spec/controllers/deals_controller_spec.rb
@@ -57,6 +57,7 @@ describe DealsController, type: :controller do
         expect(response).to be_successful
         deal = @current_user.general_deals.where(date: Date.new(2010, 7, 7)).order(created_at: :desc).first
         expect(deal.summary).to eq "a" * 61 + "..."
+        expect(controller.instance_variable_get("@deal").summary).to eq "a" * 61 + "..." # DB内だけでなくオブジェクトの状態も完全である
         expect(request.flash[:notice]).to eq "記入 2010/07/07-1 を追加しました。長すぎる摘要を64文字に短縮しました。"
       end
     end
@@ -74,7 +75,7 @@ describe DealsController, type: :controller do
            params: {
                deal: {
                    year: '2010', month: '7', day: '9',
-                   summary: 'test_complex',
+                   summary: summary,
                    summary_mode: 'unify',
                    creditor_entries_attributes: [{:account_id => :taro_cache.to_id, :amount => -800, :line_number => 0}, {:account_id => :taro_hanako.to_id, :amount => -200, :line_number => 1}],
                    debtor_entries_attributes: [{:account_id => :taro_bank.to_id, :amount => 1000, :line_number => 0}]
@@ -99,7 +100,8 @@ describe DealsController, type: :controller do
         expect(response).to be_successful
         deal = @current_user.general_deals.where(date: Date.new(2010, 7, 9)).order(created_at: :desc).first
         expect(deal.summary).to eq "a" * 61 + "..."
-        expect(request.flash[:notice]).to eq "記入 2010/07/07-1 を追加しました。長すぎる摘要を64文字に短縮しました。"
+        expect(controller.instance_variable_get("@deal").summary).to eq "a" * 61 + "..." # DB内だけでなくオブジェクトの状態も完全である
+        expect(request.flash[:notice]).to eq "記入 2010/07/09-1 を追加しました。長すぎる摘要を64文字に短縮しました。"
       end
     end
   end


### PR DESCRIPTION
# Overview
記入/更新時に摘要が長すぎるときに自動で短縮し、それを教えるようにする

# Related Issues
https://github.com/nay/kozuchi/issues/236

# Details

以下がの登録/更新が影響を受ける

* 記入
  * 残高
  * 単純明細
  * 複数明細
* 記入パターン
  * 単純明細
  * 複数明細

